### PR TITLE
670 fix the team page hide items button

### DIFF
--- a/assets/scss/ui/card.scss
+++ b/assets/scss/ui/card.scss
@@ -175,7 +175,8 @@
   .figure img {
     /* Ensure the image displays correctly */
     width: 100%;
-    height: auto;
+    height: 250px;
+    object-fit: cover;
     border-top-left-radius: 20px;
     border-top-right-radius: 20px;
   }
@@ -199,7 +200,12 @@
   }
 
   header {
-    padding: 8px 16px 16px 16px;
+    padding: 16px;
+    min-height: 90px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.5em;
     h3,
     h3 a {
       color: #ffd736;

--- a/layouts/team/list.html
+++ b/layouts/team/list.html
@@ -12,7 +12,7 @@
       {{ else }}
         <div class="accordion">
           {{ range $index, $element := .Params.teams }}
-            <div class="accordion-item{{ if eq $index 0 }}active{{ end }}">
+            <div class="accordion-item {{ if eq $index 0 }}active{{ end }}">
               <h3>{{ .title }} <span> </span></h3>
               <div class="accordion-content">
                 <p>{{ .description }}</p>


### PR DESCRIPTION
1. Fixed a prettier problem (accidentally removed essential whitespace)
2. Improved the cards a bit. Made the images of consistent height / width independent of uploaded image size & aligned the title a bit.