### PR TITLE
207 - cms adding documents

### DIFF
--- a/cms/collections.ts
+++ b/cms/collections.ts
@@ -1,3 +1,4 @@
 import { Collection as ArticlesCollection } from '../layouts/newsroom/collection';
+import { Collection as DocumentsCollection } from './documents';
 
-export default [ArticlesCollection];
+export default [ArticlesCollection, DocumentsCollection];

--- a/cms/documents.ts
+++ b/cms/documents.ts
@@ -1,0 +1,7 @@
+export const Collection = {
+  label: 'Documents',
+  name: 'documents',
+  public_folder: '/documents',
+  media_folder: '/assets/documents',
+  create: false
+};

--- a/layouts/newsroom/collection.ts
+++ b/layouts/newsroom/collection.ts
@@ -8,6 +8,8 @@ export const Collection = {
     structure: 'multiple_files',
   },
   folder: 'content/newsroom/articles',
+  public_folder: '/images/articles',
+  media_folder: '/assets/images/articles',
   create: true,
   slug: '{{ .Title | urlize }}',
   fields: [


### PR DESCRIPTION
This PR has a trick to show documents as a category in the assets management of Sveltia:

![image](https://github.com/user-attachments/assets/6831d769-82fe-424d-941a-3c05219e1c0c)

This has the downside that it also shows `Documents` as a (non-functioning) collection:

![image](https://github.com/user-attachments/assets/34ed7050-65ca-470f-bd93-88ded754324a)

But this means that it's possible to CRUD the PDF documents in the `documents` folder via a UI instead of just directly through Github. For now the benefits outweigh the costs. This workaround might be removed if https://github.com/sveltia/sveltia-cms/issues/301 is implemented.