### PR TITLE
Fix energie partner cards layout

### DIFF
--- a/assets/scss/core.scss
+++ b/assets/scss/core.scss
@@ -200,8 +200,18 @@ a.cta {
     }
 
     img {
-      max-width: 100%;
-      max-height: 100%; /* Ensure the image does not overflow */
+      min-width: 160px;
+      min-height: 90px;
+      max-width: 85%;
+      max-height: 85%;
+      width: auto;
+      height: auto;
+      object-fit: contain;
+      
+      @media (min-width: 768px) {
+        max-width: 220px;
+        max-height: 140px;
+      }
     }
   }
 

--- a/content/energie/_index.en.md
+++ b/content/energie/_index.en.md
@@ -69,6 +69,26 @@ sections:
   - type: partner-section
     title: Huidige partners
     partners:
+      - name: Bureau Veritas
+        description: |-
+          Bureau Veritas biedt wereldwijd expertise op het gebied van inspecties, certificering en cybersecurity. Ze helpen organisaties risico’s te beheersen en hun digitale weerbaarheid te vergroten.
+        url: https://cybersecurity.bureauveritas.com/
+        logo: /images/partners/DIVD%20partner%20bureau-veritas-gray.svg
+      - name: Elaad
+        description: |-
+          ElaadNL is het kennis- en innovatiecentrum op het gebied van slimme laadinfrastructuur. Het stimuleert onderzoek en samenwerking rondom elektrisch rijden en het slim laden van voertuigen binnen een duurzaam energiesysteem.
+        url: https://elaad.nl/
+        logo: /images/partners/DIVD%20partner%20ElaadNL.svg
+      - name: European Network for Cyber Security
+        description: |-
+          ENCS versterkt de digitale weerbaarheid van Europese energie- en nutsbedrijven. Ze bieden expertise, testen en kennisdeling om de cyberveiligheid van kritieke infrastructuren te verbeteren.
+        url: https://encs.eu/
+        logo: /images/partners/DIVD%20partner%20ENCS-logo-dark.svg
+      - name: Internet Cleanup Foundation
+        description: |-
+          De Internet Cleanup Foundation spoort verouderde en onveilige systemen op het internet op en helpt eigenaren om deze op te schonen. Zo dragen ze bij aan een veiliger internet voor iedereen.
+        url: https://internetcleanup.foundation/
+        logo: /images/partners/DIVD%20partner%20Internet%20cleanup%20foundation.svg
       - name: SIDN Fonds
         description: |-
           SIDN investeert in projecten met lef
@@ -78,7 +98,12 @@ sections:
           publieke waarden en maatschappelijke kant
           van het internet.
         url: https://www.sidnfonds.nl
-        logo: SIDN%20Fonds.png
+        logo: /images/partners/sidn-fund-360x200.jpg
+      - name: The Green Village
+        description: |-
+          The Green Village is een open testlocatie op de TU Delft Campus waar onderzoekers, bedrijven en overheden samen in de praktijk werken aan duurzame innovaties in de gebouwde omgeving.
+        url: https://www.thegreenvillage.org/
+        logo: /images/partners/DIVD%20partner%20the%20green%20village.svg
       - name: Topsector Energie
         description: |-
           Topsector Energie helpt bedrijven,
@@ -87,32 +112,7 @@ sections:
           werken aan het energiesysteem van de
           toekomst.
         url: https://topsectorenergie.nl/nl/
-        logo: Topsector%20Energie%202.png
-      - name: Elaad
-        description: |-
-          ElaadNL is het kennis- en innovatiecentrum op het gebied van slimme laadinfrastructuur. Het stimuleert onderzoek en samenwerking rondom elektrisch rijden en het slim laden van voertuigen binnen een duurzaam energiesysteem.
-        url: https://elaad.nl/
-        logo: /assets/images/partners/DIVD%20partner%20ElaadNL.svg
-      - name: European Network for Cyber Security
-        description: |-
-          ENCS versterkt de digitale weerbaarheid van Europese energie- en nutsbedrijven. Ze bieden expertise, testen en kennisdeling om de cyberveiligheid van kritieke infrastructuren te verbeteren.
-        url: https://encs.eu/
-        logo: /assets/images/partners/DIVD%20partner%20ENCS-logo-dark.svg
-      - name: Internet Cleanup Foundation
-        description: |-
-          De Internet Cleanup Foundation spoort verouderde en onveilige systemen op het internet op en helpt eigenaren om deze op te schonen. Zo dragen ze bij aan een veiliger internet voor iedereen.
-        url: https://internetcleanup.foundation/
-        logo: /assets/images/partners/DIVD%20partner%20Internet%20cleanup%20foundation.svg
-      - name: The Green Village
-        description: |-
-          The Green Village is een open testlocatie op de TU Delft Campus waar onderzoekers, bedrijven en overheden samen in de praktijk werken aan duurzame innovaties in de gebouwde omgeving.
-        url: https://www.thegreenvillage.org/
-        logo: /assets/images/partners/DIVD%20partner%20the%20green%20village.svg
-      - name: Bureau Veritas
-        description: |-
-          Bureau Veritas biedt wereldwijd expertise op het gebied van inspecties, certificering en cybersecurity. Ze helpen organisaties risico’s te beheersen en hun digitale weerbaarheid te vergroten.
-        url: https://cybersecurity.bureauveritas.com/
-        logo: /assets/images/partners/DIVD%20partner%20bureau-veritas-gray.svg
+        logo: /images/partners/DIVD%20partner%20topsecter%20energie.svg
       - name: jij?
         description: Download ons partnerdeck voor de mogelijkheden.
         url: https://www.divd.nl/documents/DIVD%20Partnerdeck%20Energie%202025.pdf

--- a/layouts/partials/sections/partner/partner.html
+++ b/layouts/partials/sections/partner/partner.html
@@ -1,36 +1,38 @@
 <div class="bg-[rgba(61,220,235,0.2)]">
   <div class="bg-light-black py-20 desktop:py-24 desktop:rounded-tr-[300px]">
-    <section class="container flex flex-col gap-6 text-white text-center">
-      <h2 class="tracking-wide">{{ .title }}</h2>
+    <section class="container flex flex-col gap-6 text-white">
+      <h2 class="tracking-wide text-center">{{ .title }}</h2>
 
-      <div
-        class="grid grid-cols-1 desktop:grid-cols-3 flex-wrap px-4 desktop:px-0 gap-8 mt-8">
+      <div class="grid grid-cols-1 desktop:grid-cols-3 flex-wrap px-4 desktop:px-0 gap-8 mt-8">
         {{ range .partners }}
-          <article>
-            <figure class="h-[200px] bg-white rounded-t-[20px] p-3">
-              <img
-                class="h-full w-full object-contain"
-                src="{{ .logo }}"
-                alt="Logo {{ .name }}" />
+          <div class="partner-card">
+            <figure class="partner-image">
+              {{ if hasPrefix .logo "/" }}
+                {{ with resources.Get (substr .logo 1) }}
+                  {{ partial "tools/rimg/img" (dict "img" . "alt" $.name) }}
+                {{ else }}
+                  <img src="{{ .logo }}" alt="Logo {{ .name }}" />
+                {{ end }}
+              {{ else }}
+                {{ with resources.Get .logo }}
+                  {{ partial "tools/rimg/img" (dict "img" . "alt" $.name) }}
+                {{ else }}
+                  <img src="{{ .logo }}" alt="Logo {{ .name }}" />
+                {{ end }}
+              {{ end }}
             </figure>
-
-            <div
-              class="text-left p-6 bg-black h-[260px] rounded-b-[20px] relative">
-              <h3 class="line-clamp-1 mb-4">{{ .name }}</h3>
-              <p class="line-clamp-3">
-                {{ .description }}
-              </p>
-              <div class="absolute bottom-8 left-6">
-                {{ partial "components/button/button.html" (dict
-                  "label" "Bezoek site"
-                  "url" .url
-                  "invertedColors" true
-                  "external" true
-                  )
-                }}
+            <section>
+              <div class="content">
+                <h3>{{ .name }}</h3>
+                <p>{{ .description }}</p>
               </div>
-            </div>
-          </article>
+              <nav>
+                <a class="cta external inverse" href="{{ .url }}" target="_blank">
+                  Bezoek site
+                </a>
+              </nav>
+            </section>
+          </div>
         {{ end }}
       </div>
     </section>


### PR DESCRIPTION
- Replace fixed-height partner cards with flexible card-partner layout
- Add responsive image sizing with min/max dimensions
- Improve SVG logo visibility
- Fix GitHub issue #769: more space for copy in partner cards
- Make layout consistent with partners page
- Add responsive breakpoints for mobile/desktop image sizing

Before
<img width="1511" height="681" alt="image" src="https://github.com/user-attachments/assets/da74ddff-0b5e-42c0-867c-7068b00d5ab2" />

After:

<img width="1462" height="749" alt="image" src="https://github.com/user-attachments/assets/d1a064c0-8cc3-46a8-a8f5-04f3561f47ef" />

